### PR TITLE
Add sensu tags in Opsgenie tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - Added team support for OpsGenie alerts.
+- Added sensu tags integration.
 
 ### Updated
 - Moved adding "recipients" parameter to JSON content to create_alert function. Recipients parameter is not available for close_alert.

--- a/bin/handler-opsgenie.rb
+++ b/bin/handler-opsgenie.rb
@@ -62,7 +62,9 @@ class Opsgenie < Sensu::Handler
     tags << 'unknown' if event_status >= 3
     tags << 'critical' if event_status == 2
     tags << 'warning' if event_status == 1
-    event_tags.each { |tag, value| tags << "#{tag}_#{value}" }
+    unless event_tags.nil?
+      event_tags.each { |tag,value| tags << "#{tag}_#{value}" }
+    end
 
     recipients = @json_config['opsgenie']['recipients'] if @json_config['opsgenie']['recipients']
     teams = @json_config['opsgenie']['teams'] if @json_config['opsgenie']['teams']

--- a/bin/handler-opsgenie.rb
+++ b/bin/handler-opsgenie.rb
@@ -62,7 +62,7 @@ class Opsgenie < Sensu::Handler
     tags << 'unknown' if event_status >= 3
     tags << 'critical' if event_status == 2
     tags << 'warning' if event_status == 1
-    event_tags.each { |tag,value| tags << "#{tag}_#{value}" }
+    event_tags.each { |tag, value| tags << "#{tag}_#{value}" }
 
     recipients = @json_config['opsgenie']['recipients'] if @json_config['opsgenie']['recipients']
     teams = @json_config['opsgenie']['teams'] if @json_config['opsgenie']['teams']

--- a/bin/handler-opsgenie.rb
+++ b/bin/handler-opsgenie.rb
@@ -63,7 +63,7 @@ class Opsgenie < Sensu::Handler
     tags << 'critical' if event_status == 2
     tags << 'warning' if event_status == 1
     unless event_tags.nil?
-      event_tags.each { |tag,value| tags << "#{tag}_#{value}" }
+      event_tags.each { |tag, value| tags << "#{tag}_#{value}" }
     end
 
     recipients = @json_config['opsgenie']['recipients'] if @json_config['opsgenie']['recipients']

--- a/bin/handler-opsgenie.rb
+++ b/bin/handler-opsgenie.rb
@@ -51,6 +51,10 @@ class Opsgenie < Sensu::Handler
     post_to_opsgenie(:close, alias: event_id)
   end
 
+  def event_tags
+    @event['client']['tags']
+  end
+
   def create_alert(description)
     tags = []
     tags << @json_config['opsgenie']['tags'] if @json_config['opsgenie']['tags']
@@ -58,6 +62,7 @@ class Opsgenie < Sensu::Handler
     tags << 'unknown' if event_status >= 3
     tags << 'critical' if event_status == 2
     tags << 'warning' if event_status == 1
+    event_tags.each { |tag,value| tags << "#{tag}_#{value}" }
 
     recipients = @json_config['opsgenie']['recipients'] if @json_config['opsgenie']['recipients']
     teams = @json_config['opsgenie']['teams'] if @json_config['opsgenie']['teams']


### PR DESCRIPTION
When the Opsgenie handler is triggered, the alert is created with the tags of the sensu client like this way: 

```
"tags": {
    "env": "prod",
    "application": "sensu"
}

```

In Opsgenie alert, the tags are filled:
- env_prod
- application_sensu
