### PR TITLE
Read config from already-parsed global config, not a JSON file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [1.0.0] - 2015-03-30
+### Changed
+- Changed the `-j, --jsonconfig` parameter to specify a key in the already-parsed JSON config file
+- The `-j, --jsonconfig` parameter no longer takes a JSON config file as input
+
 ## [0.0.3] - 2015-11-26
 ### Added
 - Added team support for OpsGenie alerts.

--- a/lib/sensu-plugins-opsgenie/version.rb
+++ b/lib/sensu-plugins-opsgenie/version.rb
@@ -4,9 +4,9 @@ require 'json'
 module SensuPluginsOpsgenie
   # This defines the version of the gem
   module Version
-    MAJOR = 0
+    MAJOR = 1
     MINOR = 0
-    PATCH = 3
+    PATCH = 0
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
 


### PR DESCRIPTION
Supplying a filename to read and parse the JSON out of is not the intent
of the `--jsonconfig` parameter. It's supposed to read from the global
Sensu configuration that has already been read, JSON-parsed, and merged
from `/etc/sensu/conf.d` or similar.

See the following plugins for this convention:
- [sensu-plugins-pagerduty](https://github.com/sensu-plugins/sensu-plugins-pagerduty/blob/master/bin/handler-pagerduty.rb#L35)
- [sensu-plugins-slack](https://github.com/sensu-plugins/sensu-plugins-slack/blob/master/bin/handler-slack.rb#L82)
- [sensu-plugins-hipchat](https://github.com/sensu-plugins/sensu-plugins-hipchat/blob/master/bin/handler-hipchat.rb#L42)
