### PR TITLE
Convert to extension handler

### DIFF
--- a/bin/handler-opsgenie.rb
+++ b/bin/handler-opsgenie.rb
@@ -29,6 +29,9 @@ module Sensu::Extension
       {
         type: 'extension',
         name: 'opsgenie',
+        filters: [
+          'filter-ttl-keepalive',
+        ],
       }
     end
 

--- a/bin/handler-opsgenie.rb
+++ b/bin/handler-opsgenie.rb
@@ -123,6 +123,10 @@ module Sensu::Extension
           end
 
         end
+      else
+        msg = "#{name}: avoided handling for host '#{event['client']['name']}' due to unchanged status"
+        @logger.debug(msg)
+        yield msg, 0
       end
     end
 

--- a/bin/handler-opsgenie.rb
+++ b/bin/handler-opsgenie.rb
@@ -79,7 +79,7 @@ module Sensu::Extension
                    close_alert(event)
                  end
 
-      msg_event = "#{event['action']} '#{event_id(event)}'"
+      msg_event = "#{event['action']} '#{event_alias(event)}'"
 
       # Failed connection such as timeout or bad DNS
       response.errback do
@@ -104,7 +104,7 @@ module Sensu::Extension
       end
     end
 
-    def event_id(event)
+    def event_alias(event)
       event['client']['name'] + '/' + event['check']['name']
     end
 
@@ -113,7 +113,7 @@ module Sensu::Extension
     end
 
     def close_alert(event)
-      post_to_opsgenie(:close, alias: event_id(event))
+      post_to_opsgenie(:close, alias: event_alias(event))
     end
 
     def event_tags(event)
@@ -136,7 +136,7 @@ module Sensu::Extension
       teams = @config['teams'] if @config['teams']
 
       post_to_opsgenie(action: :create,
-                       alias: event_id,
+                       alias: event_alias(event),
                        message: message,
                        description: description,
                        tags: tags.join(','),


### PR DESCRIPTION
## Pull Request Checklist

Most of the things from this checklist are missing. I wanted to get some feedback before writing tests and documentation. I'll edit the description as I make progress.
#### General
- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [ ] RuboCop passes
- [ ] Existing tests pass 
#### New Plugins
- [ ] Tests
- [ ] Add the plugin to the README
- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)
#### Purpose

This change makes the Sensu OpsGenie run as an Extension Handler, which drastically reduces the amount of CPU used. It also happens to work.
#### Known Compatablity Issues

It's completely incompatible with the regular handler version, and the script needs to be copied to `/etc/sensu/extensions`.
