### PR TITLE
Report client name as entity to OpsGenie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - Added description support for OpsGenie alerts.
+- Report the client name as `entity` to OpsGenie
 
 ## [1.0.0] - 2016-04-12
 ### Changed

--- a/bin/handler-opsgenie.rb
+++ b/bin/handler-opsgenie.rb
@@ -59,6 +59,10 @@ class Opsgenie < Sensu::Handler
     @event['client']['tags']
   end
 
+  def client_name
+    @event['client']['name']
+  end
+
   def create_alert(message)
     tags = []
     tags << @json_config['tags'] if @json_config['tags']
@@ -74,7 +78,14 @@ class Opsgenie < Sensu::Handler
     recipients = @json_config['recipients'] if @json_config['recipients']
     teams = @json_config['teams'] if @json_config['teams']
 
-    post_to_opsgenie(:create, alias: event_id, message: message, description: description, tags: tags.join(','), recipients: recipients, teams: teams)
+    post_to_opsgenie(:create,
+                     alias: event_id,
+                     message: message,
+                     description: description,
+                     entity: client_name,
+                     tags: tags.join(','),
+                     recipients: recipients,
+                     teams: teams)
   end
 
   def post_to_opsgenie(action = :create, params = {})


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
  Not necessary
- [ ] Binstubs are created if needed
  Not necessary
- [x] RuboCop passes
- [ ] Existing tests pass 
  No existing tests
#### New Plugins
- [ ] Tests
- [ ] Add the plugin to the README
- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)
#### Purpose

Report the Sensu client name as the `entity` to OpsGenie.  The [OpsGenie alert API](https://www.opsgenie.com/docs/web-api/alert-api#createAlertRequest) defines `entity` as:

> The entity the alert is related to.

This is useful in the OpsGenie advanced integration settings in order to, for example, automatically generate a link to a runbook or other documentation based on the client name.
#### Known Compatablity Issues
