### PR TITLE
Add HTTP proxy and EU API endpoint support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- Added support for HTTP proxies and overriding API endpoint (@bodgit)
 
 ## [5.0.0] - 2019-03-05
 ### Breaking Changes

--- a/bin/check-opsgenie-heartbeat.rb
+++ b/bin/check-opsgenie-heartbeat.rb
@@ -91,7 +91,7 @@ class OpsgenieHeartbeat < Sensu::Plugin::Check::CLI
     u = URI.parse(config[:proxy_url])
     proxy = [u.host, u.port, u.user, u.password].compact
 
-    Net::HTTP.start(uri.host, uri.port, *proxy, :use_ssl => true, :verify_mode => OpenSSL::SSL::VERIFY_NONE) do |http|
+    Net::HTTP.start(uri.host, uri.port, *proxy, use_ssl: true, verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
       request = Net::HTTP::Post.new(uri.request_uri, 'Authorization' => "GenieKey #{config[:api_key]}")
       http.request(request)
     end

--- a/bin/handler-opsgenie.rb
+++ b/bin/handler-opsgenie.rb
@@ -200,7 +200,7 @@ class Opsgenie < Sensu::Handler
     u = URI.parse(config[:proxy_url])
     proxy = [u.host, u.port, u.user, u.password].compact
 
-    Net::HTTP.start(uri.host, uri.port, *proxy, :use_ssl => true, :verify_mode => OpenSSL::SSL::VERIFY_NONE) do |http|
+    Net::HTTP.start(uri.host, uri.port, *proxy, use_ssl: true, verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
       request = Net::HTTP::Post.new(uri.request_uri, 'Authorization' => "GenieKey #{json_config['customerKey']}", 'Content-Type' => 'application/json')
       request.body = params.to_json
       http.request(request)


### PR DESCRIPTION
## Pull Request Checklist

Fixes #77 
Fixes #78 

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [ ] Existing tests pass

#### Purpose

Adds support for HTTP proxies and changing the API endpoint with `--proxy` and `--api` respectively. Defaults are no proxy and the original `api.opsgenie.com` API endpoint.

#### Known Compatibility Issues
