### PR TITLE
Use responders API field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 ### Breaking Changes
 - Bump sensu-plugin version from `~> 2.0` to `~> 4.0` for Sensu 1.x to Sensu Go event conversion you can read the changelog entries for [4.0](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#400---2018-02-17) and [3.0](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#300---2018-12-04)
 - drop support and testing for ruby 2.1 and 2.2 as they are EOL
+- Use the responders API field instead of deprecated recipients and teams fields (@bodgit)
 =======
 
 ## [4.3.0] - 2018-03-21

--- a/README.md
+++ b/README.md
@@ -23,7 +23,15 @@
       { "name": "the-team" },
       { "id": "4513b7ea-3b91-438f-b7e4-e3e54af9147c" }
     ],
-    "recipients": "the-recipients",
+    "users": [
+      { "username": "trinity@opsgenie.com" }
+    ],
+    "escalations": [
+      { "name": "Nightwatch Escalation" }
+    ],
+    "schedules": [
+      { "id": "80564037-1984-4f38-b98e-8a1f662df552" }
+    ],
     "source": "alert-source",
     "overwrite_quiet_hours": true,
     "tags": ["sensu"]
@@ -94,16 +102,11 @@ the Sensu check name, _e.g._:
 web01 : check_mysql_access
 ```
 
-### Teams
+### Responders
 
-The OpsGenie _team_ alert field uses the values in the Sensu check configuration
-if any, otherwise it uses the value from the handler configuration.
-
-### Recipients
-
-The OpsGenie _recipients_ alert field uses the values in the Sensu check
-configuration if any, otherwise it uses the value from the handler
-configuration.
+The OpsGenie _responders_ alert field combines the values of the teams, users,
+escalations, and schedules values from the Sensu check configuration if any,
+otherwise it uses the values from the handler configuration.
 
 ### Alias
 

--- a/bin/handler-opsgenie.rb
+++ b/bin/handler-opsgenie.rb
@@ -120,6 +120,16 @@ class Opsgenie < Sensu::Handler
     @event['client']['name']
   end
 
+  def responders
+    %w[user team escalation schedule].reduce([]) do |r, type|
+      k = type + 's'
+      if json_config.key?(k)
+        r += json_config[k].map { |x| x.merge(type: type) }
+      end
+      r
+    end
+  end
+
   def create_alert
     post_to_opsgenie(:create,
                      alias:       event_id,
@@ -127,8 +137,7 @@ class Opsgenie < Sensu::Handler
                      description: description,
                      entity:      client_name,
                      tags:        tags,
-                     recipients:  json_config['recipients'],
-                     teams:       json_config['teams'])
+                     responders:  responders)
   end
 
   def event_priority
@@ -183,7 +192,7 @@ class Opsgenie < Sensu::Handler
       puts "Message: #{params[:message]}"
       puts "Tags: #{params[:tags]}"
       puts "Entity: #{params[:entity]}"
-      puts "Teams: #{params[:teams]}"
+      puts "Responders: #{params[:responders]}"
       puts "Alias: #{params[:alias]}"
       puts "Description: #{params[:description]}"
     end


### PR DESCRIPTION
Create a responders field from the users, teams, escalations, and
schedules values in Sensu. The teams value can be used as before and the
other three work the same way. The correct type key is added for you.

Because the old recipients value could contain any of the above, I
haven't tried to map it to the new values so this is a backwards
incompatible change as it won't use it any longer, however the teams
value still works as before.

## Pull Request Checklist

Fixes #83 

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues

The existing teams value is still used but the recipients value is no longer used. Instead users, escalations and schedules should be utilised.
